### PR TITLE
set project name with repository if exists

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -99,6 +99,11 @@ module.exports = yeoman.generators.Base.extend({
         this.config.set('changeFileNaming', props.changeFileNaming);
         this.config.set('useES6', props.useES6);
 
+        var repoUrl = this.config.get('projectRepository');
+        if(repoUrl.match('\/(.*?).git') !== null){
+          this.config.set('projectName', repoUrl.match('\/(.*?).git')[1]);
+        } 
+
         done();
       }.bind(this));
     },


### PR DESCRIPTION
This close #133 

Hey @njam3 I solved in this way. After running all the prompts if you set a repository and the regular expression match (this is going to match if you set any correct url) we change the project name to this name, otherwise its going to use the folder name that was set it previously.
