### PR TITLE
getting rid of random for section key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 bundle.js
 /output
 /test/output
+.idea

--- a/templates/react/src/sections/App/index.js
+++ b/templates/react/src/sections/App/index.js
@@ -29,7 +29,7 @@ class App extends React.Component {
   }
   getContent() {
     if (this.props.ready) {
-      return React.cloneElement(this.props.children, { key: this.props.section+'-'+Math.random(), width: this.state.width, height: this.state.height});
+      return React.cloneElement(this.props.children, { key: this.props.section, width: this.state.width, height: this.state.height});
     } else {
       return <Preloader 
         onProgress={this.props.onProgress}


### PR DESCRIPTION
‘random’ in key name is causing section re-creation on window resize as
getContent() is called in rendered function. A new section is returned
every time so ‘componentWillLeave’ is going to be called on existing
component and ‘componentWillEnter’ on newly created section whenever
window resize is triggered. I believe this should go away.