### PR TITLE
Implemented runnning ui tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "nyg": "^2.0.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "rimraf": "^2.5.2"
+  },
   "scripts": {
     "test": "node test/"
   },

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/Jam3"
   },
   "scripts": {
-    "start": "npm run copy && npm run style && npm run dev",
+    "start": "npm run assets && npm run dev",
+    "assets": "npm run copy && npm run style",
     "copy": "node scripts/copy.js",
     "style": "node scripts/style.js",
     "dev": "node scripts/dev.js",
@@ -18,7 +19,9 @@
     "release-copy": "node scripts/copy.js --env=production",
     "release-gzip": "node scripts/gzip.js --env=production",
     "release-clean": "node scripts/clean.js --env=production",
-    "lowercase": "node scripts/lowercase.js"
+    "lowercase": "node scripts/lowercase.js",
+    "ui": "node scripts/selectUI.js | run-run NODE_ENV=development ASSET_PATH=./assets/ -- 'npm run ui-run'",
+    "ui-run": "npm run assets && budo {SCRIPT} --live --open --serve bundle.js --dir build/"
   },
   "license": "ISC",
   "repository": "{{repo}}",
@@ -72,7 +75,9 @@
     "babel-runtime": "^5.8.34",
     "babel-preset-es2015": "^6.3.13"{{#is framework 'react'}},
     "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-1": "^6.5.0"{{/is}}{{/if}}
+    "babel-preset-stage-1": "^6.5.0",{{/is}}{{/if}}
+    "run-run": "^1.1.0",
+    "inquirer": "^1.0.2"
   },
   "browserify": {
     "transform": [{{#is framework 'bigwheel'}}

--- a/templates/base/static/index.html
+++ b/templates/base/static/index.html
@@ -13,8 +13,8 @@
   {{#if pushState}}<base href="/">{{/if}}
   <link rel="stylesheet" type="text/css" href="main.css">\{{#is NODE_ENV "production"}}\{{#if vendor}}
   <script type="text/javascript" src="\{{vendor}}"></script>\{{/if}}\{{/is}}
-  <script type="text/javascript" src="bundle.js"></script>
 </head>
   <body>
   </body>
+  <script type="text/javascript" src="bundle.js"></script>
 </html>

--- a/templates/base/static/index.html
+++ b/templates/base/static/index.html
@@ -11,10 +11,10 @@
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon">
   <meta name="description" content="">
   {{#if pushState}}<base href="/">{{/if}}
-  <link rel="stylesheet" type="text/css" href="main.css">\{{#is NODE_ENV "production"}}\{{#if vendor}}
-  <script type="text/javascript" src="\{{vendor}}"></script>\{{/if}}\{{/is}}
+  <link rel="stylesheet" type="text/css" href="main.css">
 </head>
-  <body>
+  <body>\{{#is NODE_ENV "production"}}\{{#if vendor}}
+    <script type="text/javascript" src="\{{vendor}}"></script>\{{/if}}\{{/is}}
+    <script type="text/javascript" src="bundle.js"></script>
   </body>
-  <script type="text/javascript" src="bundle.js"></script>
 </html>

--- a/templates/scripts/selectUI.js
+++ b/templates/scripts/selectUI.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var inquirer = require('inquirer');
+
+var pathToUIDir = path.join(__dirname, '..', 'test');
+var files = fs.readdirSync(pathToUIDir)
+.filter(function(file) {
+  var isNotHidden = file.charAt(0) !== '.';
+  var isNotFolderWithoutIndex = true;
+  var pathFile = path.join(pathToUIDir, file);
+
+  if(isNotHidden && fs.statSync(pathFile).isDirectory()) {
+    isNotFolderWithoutIndex = fs.existsSync(path.join(pathFile, 'index.js'));
+  }
+
+  return isNotHidden && isNotFolderWithoutIndex;
+});
+
+if(files.length > 1) {
+  var prompt = inquirer.createPromptModule({
+    output: process.stderr
+  });
+
+  prompt([
+    { name: 'SCRIPT', type: 'rawlist', choices: files, message: 'Select a UI component you\'d like to test:' }
+  ])
+  .then(function(result) {
+    result.SCRIPT = path.join(pathToUIDir, result.SCRIPT);
+
+    console.log(JSON.stringify(result));
+  });
+} else if(files.length === 1) {
+  console.log(JSON.stringify({
+    SCRIPT: path.join(pathToUIDir, files[ 0 ])
+  }));
+}


### PR DESCRIPTION
UI tests would live in the generated `test/` folder.

UI tests are run using `run-run` using `budo`.

`budo` will serve `build/index.html`, the ui test will be served at `bundle.js`, the main style for the site `main.css`.

Basically with ui tests it will be served the exact same as the site itself.

Some slight changes to npm scripts like combining `npm run copy && npm run style` as `npm run asset`. I also dropped the `<script src="bundle.js" />` just under `<body>`
