### PR TITLE
Clean up package.json template for budo/garnish

### DIFF
--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -45,11 +45,10 @@
     "redux-devtools-log-monitor": "^1.0.9"{{/is}}
   },
   "devDependencies": {
-    "budo": "^8.0.4",
+    "budo": "^9.0.0",
     "rimraf": "^2.5.2",
     "envify": "^3.4.0",
     "concat-stream": "^1.5.1",
-    "garnish": "^4.1.1",
     "graceful-fs": "^4.1.3",
     "handlebars": "^4.0.5",
     "glob": "^6.0.1",


### PR DESCRIPTION
- Bump to budo@9 (better support for SSL)
- Remove `garnish` since it's no longer needed in budo