### PR TITLE
Update budo, add LiveReload CSS error reporting

### DIFF
--- a/templates/base/README.md
+++ b/templates/base/README.md
@@ -90,6 +90,22 @@ To debug Redux, use this browser extension: http://zalmoxisus.github.io/redux-de
 $ npm run release
 ```
 
+## BROWSER SUPPORT
+
+[Browserify](https://www.npmjs.com/package/browserify) recently reduced support for older IE browsers (IE10 and below). This is due to the updated `Buffer` module. If you wish to support these browsers and are planning to use the `Buffer` module or use a seperate module that uses it, consider installing this [browser polyfill](https://github.com/inexorabletash/polyfill/blob/master/typedarray.js).
+
+Optionally you can install version 4 of the `Buffer` module by running this command.
+
+`npm install buffer@^4 --save-dev`  
+
+You will also have to update the browserify bundle options using the require flag:
+
+`-r buffer/:buffer`
+
+This will require editing the `release.js` and `dev.js` scripts.
+
+For more information, check out: [https://github.com/substack/node-browserify/pull/1678](https://github.com/substack/node-browserify/pull/1678)
+
 ## RUN TESTS
 
 Use [Budo](http://npmjs.com/budo/) to develop and test your modules independently before integrating into the framework.

--- a/templates/base/config.json
+++ b/templates/base/config.json
@@ -10,6 +10,7 @@
     "BASENAME": "/",
     "JPEG_QUALITY": 80,
     "templateBlacklist": [],
+    "liveReloadClient": true,
     "htpasswd": {{#if password}}"{{passLocation}}"{{else}}false{{/if}},
     "env": {}
   },

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -50,7 +50,7 @@
     "stats.js": "0.16.0"{{/is}}
   },
   "devDependencies": {
-    "budo": "^9.0.0",
+    "budo": "^10.0.3",
     "rimraf": "^2.5.2",
     "envify": "^3.4.0",
     "concat-stream": "^1.5.1",

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -75,7 +75,7 @@
     "uglify-js": "^2.6.1",
     "brfs": "^1.2.0",{{#is framework 'bigwheel'}}
     "browserify-shim": "^3.8.0",{{/is}}
-    "browserify": "^12.0.1"{{#if useES6}},
+    "browserify": "^14.1.0"{{#if useES6}},
     "babelify": "^7.2.0",
     "babel-runtime": "^5.8.34",
     "babel-preset-es2015": "^6.3.13"{{#is framework 'react'}},

--- a/templates/scripts/dev.js
+++ b/templates/scripts/dev.js
@@ -4,7 +4,24 @@ var config = require('./config');
 var budo = require('budo');
 var style = require('./style');
 var copy = require('./copy');
+var fs = require('fs');
 
+var useLiveClient = config.liveReloadClient;
+var liveOpts = useLiveClient ? {
+  // If we are making frequent changes to ./live.js
+  // Then we should set this to false so we don't need to
+  // re-start budo each time. :)
+  cache: true,
+  // This is only needed to debug our LiveReload client
+  // e.g. as above, you may want this to true if you're changing it!
+  debug: false,
+  // Expose LiveReload client to window.require('budo-livereload')
+  expose: true,
+  // Additional script(s) to include after the LiveReload client
+  include: require.resolve('./live.js')
+} : undefined;
+
+var wss;
 var b = budo(config.entry, {
   serve: config.bundle,
   open: true,
@@ -12,20 +29,33 @@ var b = budo(config.entry, {
   stream: process.stdout{{#if pushState}},
   pushstate: true{{/if}}
 });
-b.live();
+b.live(liveOpts);
 b.watch(['**/*.{html,css,less,scss}',config.raw+'**/*.*']);
+b.on('connect', function (ev) {
+  if (useLiveClient) wss = ev.webSocketServer;
+});
 b.on('watch',function(e,file) {
+  var ext = path.extname(file);
   if (file.indexOf(path.basename(config.raw))>-1) {
     copy(file);
   } else if (file.indexOf('.less')>-1 || file.indexOf('.scss')>-1) {
-    style(function() {
-      b.reload('main.css');
+    style(function(err) {
+      if (err) {
+        sendClientPopup(err);
+      }
     });
-  } else {
+  } else if (ext && /\.(css|html?)$/i.test(ext)) {
     b.reload(file);
   }
 });
-b.on('pending',b.reload.bind(b));
-b.on('update',function() {
-  b.reload(config.bundle);
+b.on('pending', function() {
+  b.reload();
 });
+
+function sendClientPopup (data) {
+  if (!wss || !useLiveClient) return;
+  var message = JSON.stringify(data);
+  wss.clients.forEach(function (socket) {
+    socket.send(message);
+  });
+}

--- a/templates/scripts/less/style.js
+++ b/templates/scripts/less/style.js
@@ -21,7 +21,7 @@ var createLess = function(callback) {
   running = true;
   fs.readFile(config.style,'UTF-8',function(err,data) {
     if (!err) {
-      mkdirp(config.output,function(err) {
+      mkdirp(path.basename(config.output), function (err) {
         if (!err) {
           data += createModifyVars({ASSET_PATH: config.ASSET_PATH});
           less.render(data,{
@@ -38,7 +38,7 @@ var createLess = function(callback) {
               fs.writeFile(path.join(config.output,lessOutput),output.css,function(err) {
                 console.log((err) ? '\x1b[31m cannot write css file.\x1b[0m' : '\x1b[32m successfully wrote css file.\x1b[0m');
                 running = false;
-                if (callback) callback();
+                if (callback) callback(null);
               });
               fs.writeFile(path.join(config.output,lessOutput+'.map'),output.map,function(err) {
                 console.log((err) ? '\x1b[31m cannot write css map file.\x1b[0m' : '\x1b[32m successfully wrote css map file.\x1b[0m');
@@ -46,6 +46,7 @@ var createLess = function(callback) {
             } else {
               console.error(err);
               running = false;
+              if (callback) callback(err);
             }
           });
         }

--- a/templates/scripts/less/style.js
+++ b/templates/scripts/less/style.js
@@ -44,7 +44,6 @@ var createLess = function(callback) {
                 console.log((err) ? '\x1b[31m cannot write css map file.\x1b[0m' : '\x1b[32m successfully wrote css map file.\x1b[0m');
               });
             } else {
-              console.error(err);
               running = false;
               if (callback) callback(err);
             }

--- a/templates/scripts/live.js
+++ b/templates/scripts/live.js
@@ -1,0 +1,83 @@
+// This handles the popup for CSS syntax errors.
+// Eventually we might find other interesting use-cases
+// for a custom LiveReload client. :)
+
+var popupContainer, popupText;
+var client = require('budo-livereload');
+
+// when we receive data from the node scripts
+client.listen(function (data) {
+  // hide popup on every reload
+  clearPopup();
+
+  // if there was an issue with CSS
+  if (data && data.formatted) {
+    console.error(data.formatted);
+    popup(data.formatted);
+  }
+});
+
+function clearPopup () {
+  if (popupContainer && popupContainer.parentNode) {
+    popupContainer.parentNode.removeChild(popupContainer);
+  }
+  if (popupText && popupText.parentNode) {
+    popupText.parentNode.removeChild(popupText);
+  }
+  popupContainer = null;
+  popupText = null;
+}
+
+function popup (message) {
+  if (popupText) {
+    popupText.textContent = message;
+    return;
+  }
+
+  var element = document.createElement('div');
+  var child = document.createElement('pre');
+  child.textContent = message;
+
+  css(element, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '100%',
+    zIndex: '100000000',
+    padding: '0',
+    margin: '0',
+    'box-sizing': 'border-box',
+    background: 'transparent',
+    display: 'block',
+    overflow: 'initial'
+  });
+  css(child, {
+    padding: '20px',
+    overflow: 'initial',
+    zIndex: '100000000',
+    'box-sizing': 'border-box',
+    background: '#fff',
+    display: 'block',
+    'font-size': '12px',
+    'font-weight': 'normal',
+    'font-family': 'monospace',
+    'word-wrap': 'break-word',
+    'white-space': 'pre-wrap',
+    color: '#ff0000',
+    margin: '10px',
+    border: '1px dashed hsla(0, 0%, 50%, 0.25)',
+    borderRadius: '5px',
+    boxShadow: '0px 10px 20px rgba(0, 0, 0, 0.2)'
+  });
+  element.appendChild(child);
+  document.body.appendChild(element);
+  popupText = child;
+  popupContainer = element;
+}
+
+function css (element, obj) {
+  for (var k in obj) {
+    if (obj.hasOwnProperty(k)) element.style[k] = obj[k];
+  }
+  return obj;
+}

--- a/templates/scripts/scss/style.js
+++ b/templates/scripts/scss/style.js
@@ -47,14 +47,12 @@ var createSass = function (callback) {
               },function(err) {
                 console.log('\x1b[31m cannot process css file.\x1b[0m');
                 running = false;
-                console.error(err);
                 if (callback) callback(err);
               });
               fs.writeFile(path.join(config.output, sassOutput + '.map'), output.map, function (err) {
                 console.log((err) ? '\x1b[31m cannot write css map file.\x1b[0m' : '\x1b[32m successfully wrote css map file.\x1b[0m');
               });
             } else {
-              console.error(err.formatted ? err.formatted : err);
               running = false;
               if (callback) callback(err);
             }

--- a/templates/scripts/scss/style.js
+++ b/templates/scripts/scss/style.js
@@ -21,7 +21,7 @@ var createSass = function (callback) {
   running = true;
   fs.readFile(config.style, 'UTF-8', function (err, data) {
     if (!err) {
-      mkdirp(config.output, function (err) {
+      mkdirp(path.basename(config.output), function (err) {
         if (!err) {
           data = createModifyVars({
             ASSET_PATH: config.ASSET_PATH
@@ -42,18 +42,21 @@ var createSass = function (callback) {
                 fs.writeFile(path.join(config.output, sassOutput), output.css + ((srcMap && srcMap[0]) ? '\n'+srcMap[0] : ''), function (err) {
                   console.log((err) ? '\x1b[31m cannot write css file.\x1b[0m' : '\x1b[32m successfully wrote css file.\x1b[0m');
                   running = false;
-                  if (callback) callback();
+                  if (callback) callback(null);
                 });
-              },function() {
+              },function(err) {
                 console.log('\x1b[31m cannot process css file.\x1b[0m');
                 running = false;
+                console.error(err);
+                if (callback) callback(err);
               });
               fs.writeFile(path.join(config.output, sassOutput + '.map'), output.map, function (err) {
                 console.log((err) ? '\x1b[31m cannot write css map file.\x1b[0m' : '\x1b[32m successfully wrote css map file.\x1b[0m');
               });
             } else {
-              console.error(err);
+              console.error(err.formatted ? err.formatted : err);
               running = false;
+              if (callback) callback(err);
             }
           });
         }


### PR DESCRIPTION
When you make a CSS error, there is a popup box that appears in-browser. When you fix the error, it should disappear. It can be restyled in `scripts/live.js`.

![screen shot 2017-04-21 at 12 45 24 pm](https://cloud.githubusercontent.com/assets/1383811/25287776/b8cf6798-2690-11e7-9345-f69d6d5658a7.png)

I also updated a couple small things with the dev script to make sure it's not triggering duplicate LiveReload events, and updated to latest budo.

