### PR TITLE
Removed es6 prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd your-project-directory
 nyg nyg-jam3
 ```
 
-You will then be prompted with a number of questions, which will define the project. The appropriate files will then be copied to the current directory and it will install all your needed dependencies. Congratulations, you are now setup with the basis of a Jam3 project. 
+You will then be prompted with a number of questions, which will define the project. The appropriate files will then be copied to the current directory and it will install all your needed dependencies. Congratulations, you are now setup with the basis of a Jam3 project.
 
 ## Prompts
 
@@ -49,17 +49,13 @@ Whether file names will follow the convention of [folder name]/[folder name].js 
 Default: true  
 Whether to use push states in the application, if false, uses hashbangs. This will setup the proper configuration in the framework and the .htaccess file.
 
-`Would you like to use ES6?`  
-Default: true  
-Whether to use ES6 and babel transpilation. Sets up a .babelrc file and all necessary dependencies.
-
 `What css preprocessor will your project use?`  
 Default: SCSS  
 Which css preprocessor should be setup on the project, defaults to SASS, but LESS is also an option.
 
 `Separate common npm modules into vendor.js?`  
 Default: true  
-Whether to separate all npm modules into a separate vender.js file, limiting the bundle.js file to just custom code. 
+Whether to separate all npm modules into a separate vender.js file, limiting the bundle.js file to just custom code.
 
 `What backend language would you like to use?`  
 Default: PHP  

--- a/index.js
+++ b/index.js
@@ -56,12 +56,6 @@ var prompts = [{
   default: true,
   when: function(answers) { return answers.framework!=='none'; }
 },{
-  type: "confirm",
-  name: "useES6",
-  message: "Would you like to use ES6?",
-  default: true,
-  when: function(answers) { return answers.framework==='bigwheel' || answers.framework==='none'; }
-},{
   type: "list",
   message: "What css preprocessor will your project use?",
   name: "css",
@@ -130,50 +124,41 @@ function onPostPrompt() {
   var repo = gen.config.get('repo').split('/');
   repo = repo[repo.length-1].toLowerCase().replace('.git','');
   gen.config.set('repoName', repo || '');
-  if (gen.config.get('framework')!=='none' && gen.config.get('framework')!=='bigwheel') gen.config.set('useES6',true);
 }
 
 function onPostCopy() {
   var done = gen.async();
   fs.rename(path.join(gen.cwd,'gitignore'),path.join(gen.cwd,'.gitignore'),function() {
     if (gen.config.get('framework')!=='none') {
-      if (gen.config.get('useES6')) {
-        gen.copy('templates/.babelrc','.babelrc',function() {
-          if (gen.config.get('sectionNames') && gen.config.get('framework')==='react') {
-            var style = gen.config.get('css');
-            var files = [
-              [path.join(gen.cwd,'src/components/Preloader/style.'+style),path.join(gen.cwd,'src/components/Preloader/Preloader.'+style)],
-              [path.join(gen.cwd,'src/components/Rotate/index.js'),path.join(gen.cwd,'src/components/Rotate/Rotate.js')],
-              [path.join(gen.cwd,'src/components/Rotate/style.'+style),path.join(gen.cwd,'src/components/Rotate/Rotate.'+style)],
-              [path.join(gen.cwd,'src/components/MobileFullscreenVideo/index.js'),path.join(gen.cwd,'src/components/MobileFullscreenVideo/MobileFullscreenVideo.js')],
-              [path.join(gen.cwd,'src/components/MobileFullscreenVideo/style.'+style),path.join(gen.cwd,'src/components/MobileFullscreenVideo/MobileFullscreenVideo.'+style)],
-              [path.join(gen.cwd,'src/components/VideoPlayer/index.js'),path.join(gen.cwd,'src/components/VideoPlayer/VideoPlayer.js')],
-              [path.join(gen.cwd,'src/components/VideoPlayer/style.'+style),path.join(gen.cwd,'src/components/VideoPlayer/VideoPlayer.'+style)],
-              [path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/index.js'),path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/VideoPoster.js')],
-              [path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/style.'+style),path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/VideoPoster.'+style)],
-              [path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/index.js'),path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/VideoTimeline.js')],
-              [path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/style.'+style),path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/VideoTimeline.'+style)],
-              [path.join(gen.cwd,'src/sections/App/style.'+style),path.join(gen.cwd,'src/sections/App/App.'+style)],
-              [path.join(gen.cwd,'src/components/HamburgerButton/index.js'),path.join(gen.cwd,'src/components/HamburgerButton/HamburgerButton.js')],
-              [path.join(gen.cwd,'src/components/HamburgerButton/style.'+style),path.join(gen.cwd,'src/components/HamburgerButton/HamburgerButton.'+style)]
-            ];
-            renameFiles(files,function() {
-              createSections(gen,done);
-            });
-          } else {
+      gen.copy('templates/.babelrc','.babelrc',function() {
+        if (gen.config.get('sectionNames') && gen.config.get('framework')==='react') {
+          var style = gen.config.get('css');
+          var files = [
+            [path.join(gen.cwd,'src/components/Preloader/style.'+style),path.join(gen.cwd,'src/components/Preloader/Preloader.'+style)],
+            [path.join(gen.cwd,'src/components/Rotate/index.js'),path.join(gen.cwd,'src/components/Rotate/Rotate.js')],
+            [path.join(gen.cwd,'src/components/Rotate/style.'+style),path.join(gen.cwd,'src/components/Rotate/Rotate.'+style)],
+            [path.join(gen.cwd,'src/components/MobileFullscreenVideo/index.js'),path.join(gen.cwd,'src/components/MobileFullscreenVideo/MobileFullscreenVideo.js')],
+            [path.join(gen.cwd,'src/components/MobileFullscreenVideo/style.'+style),path.join(gen.cwd,'src/components/MobileFullscreenVideo/MobileFullscreenVideo.'+style)],
+            [path.join(gen.cwd,'src/components/VideoPlayer/index.js'),path.join(gen.cwd,'src/components/VideoPlayer/VideoPlayer.js')],
+            [path.join(gen.cwd,'src/components/VideoPlayer/style.'+style),path.join(gen.cwd,'src/components/VideoPlayer/VideoPlayer.'+style)],
+            [path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/index.js'),path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/VideoPoster.js')],
+            [path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/style.'+style),path.join(gen.cwd,'src/components/VideoPlayer/VideoPoster/VideoPoster.'+style)],
+            [path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/index.js'),path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/VideoTimeline.js')],
+            [path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/style.'+style),path.join(gen.cwd,'src/components/VideoPlayer/VideoTimeline/VideoTimeline.'+style)],
+            [path.join(gen.cwd,'src/sections/App/style.'+style),path.join(gen.cwd,'src/sections/App/App.'+style)],
+            [path.join(gen.cwd,'src/components/HamburgerButton/index.js'),path.join(gen.cwd,'src/components/HamburgerButton/HamburgerButton.js')],
+            [path.join(gen.cwd,'src/components/HamburgerButton/style.'+style),path.join(gen.cwd,'src/components/HamburgerButton/HamburgerButton.'+style)]
+          ];
+          renameFiles(files,function() {
             createSections(gen,done);
-          }
-        });
-      } else {
-        createSections(gen,done);
-      }
+          });
+        } else {
+          createSections(gen,done);
+        }
+      });
     } else {
       fs.writeFile(path.join(gen.cwd,'src/index.js'),'',function() {
-        if (gen.config.get('useES6')) {
-          gen.copy('templates/.babelrc','.babelrc',done);
-        } else {
-          done();
-        }
+        gen.copy('templates/.babelrc','.babelrc',done);
       });
     }
     if (gen.config.get('password') !== '') {

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -80,7 +80,7 @@
     "uglify-js": "^2.6.1",
     "brfs": "^1.2.0",{{#is framework 'bigwheel'}}
     "browserify-shim": "^3.8.0",{{/is}}
-    "browserify": "^14.1.0"{{#if useES6}},
+    "browserify": "^14.1.0",
     "babelify": "^7.2.0",
     "babel-runtime": "^5.8.34",
     "babel-preset-es2015": "^6.3.13"{{#is framework 'react'}},
@@ -89,13 +89,13 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-1": "^6.5.0",
-    "stringify": "3.2.0"{{/is}}{{/if}}
+    "stringify": "3.2.0"{{/is}}
   },
   "browserify": {
     "transform": [{{#is framework 'bigwheel'}}
       "browserify-shim",
-      "brfs",{{/is}}{{#if useES6}}
-      "babelify",{{/if}}
+      "brfs",{{/is}}
+      "babelify",
       "envify"{{#is framework 'react'}},
       ["stringify", {"extensions": [".svg"], "minify": true}]{{/is}}
     ]

--- a/templates/sections/bigwheel/normal/index.js
+++ b/templates/sections/bigwheel/normal/index.js
@@ -4,35 +4,37 @@ var hbs = require('handlebars');
 var domify = require('domify');
 var model = require('../../model');
 var Tween = require('gsap');
-{{#if useES6}}
+
 class {{section}} {
   constructor() {
-    
-  }{{else}}
-function {{section}}() {}
-{{section}}.prototype = { {{/if}}
-  {{#if useES6}}init{{else}}init: function{{/if}}(req, done) {
+  }
+
+  init(req, done) {
     this.dom = domify(hbs.compile(fs.readFileSync(__dirname + '/template.hbs', 'utf8'))(model[req.route]));
     document.body.appendChild(this.dom);
     Tween.set(this.dom, {
       opacity: 0
     });
     done();
-  }{{#unless useES6}},{{/unless}}
-  {{#if useES6}}resize{{else}}resize: function{{/if}}(w, h) {}{{#unless useES6}},{{/unless}}
-  {{#if useES6}}animateIn{{else}}animateIn: function{{/if}}(req, done) {
+  }
+
+  resize(w, h) {}
+
+  animateIn(req, done) {
     Tween.to(this.dom, 1, {
       opacity: 1,
       onComplete: done
     });
-  }{{#unless useES6}},{{/unless}}
-  {{#if useES6}}animateOut{{else}}animateOut: function{{/if}}(req, done) {
+  }
+
+  animateOut(req, done) {
     Tween.to(this.dom, 1, {
       opacity: 0,
       onComplete: done
     });
-  }{{#unless useES6}},{{/unless}}
-  {{#if useES6}}destroy{{else}}destroy: function{{/if}}(req, done) {
+  }
+
+  destroy(req, done) {
     this.dom.parentNode.removeChild(this.dom);
     done();
   }

--- a/templates/sections/bigwheel/preloader/index.js
+++ b/templates/sections/bigwheel/preloader/index.js
@@ -4,38 +4,39 @@ var hbs = require('handlebars');
 var domify = require('domify');
 var model = require('../../model');
 var Tween = require('gsap');
-{{#if useES6}}
+
 class Preloader {
   constructor(onComplete) {
     this.preloaded = onComplete;
-  }{{else}}
-function Preloader(onComplete) {
-  this.preloaded = onComplete;
-}
-Preloader.prototype = { {{/if}}
-  {{#if useES6}}init{{else}}init: function{{/if}}(req, done) {
+  }
+
+  init(req, done) {
     this.dom = domify(hbs.compile(fs.readFileSync(__dirname + '/template.hbs', 'utf8'))());
     document.body.appendChild(this.dom);
     Tween.set(this.dom, {
       opacity: 0
     });
     done();
-  }{{#unless useES6}},{{/unless}}
-  {{#if useES6}}resize{{else}}resize: function{{/if}}(w, h) {}{{#unless useES6}},{{/unless}}
-  {{#if useES6}}animateIn{{else}}animateIn: function{{/if}}(req, done) {
+  }
+
+  resize(w, h) {}
+
+  animateIn(req, done) {
     Tween.to(this.dom, 1, {
       opacity: 1,
       onComplete: done
     });
     this.preloaded();
-  }{{#unless useES6}},{{/unless}}
-  {{#if useES6}}animateOut{{else}}animateOut: function{{/if}}(req, done) {
+  }
+
+  animateOut(req, done) {
     Tween.to(this.dom, 1, {
       opacity: 0,
       onComplete: done
     });
-  }{{#unless useES6}},{{/unless}}
-  {{#if useES6}}destroy{{else}}destroy: function{{/if}}(req, done) {
+  }
+
+  destroy(req, done) {
     this.dom.parentNode.removeChild(this.dom);
     done();
   }


### PR DESCRIPTION
Not sure if we're completely removing support for sub ES6 javascript flavours? If so I can delete the es6 conditionals in `templates/sections/bigwheel/normal/index.js` and `templates/sections/preloader/index.js`, as well as any other conditionals relating to es6 wherever they may be. 